### PR TITLE
chore(deps): upgrade swa version to v2 for fixing dev run issue in example

### DIFF
--- a/examples/azure-staticwebapp/README.md
+++ b/examples/azure-staticwebapp/README.md
@@ -43,7 +43,7 @@ Here you can find a [working example][example] of this project deployed to Azure
 
 ## Running the example
 
-To run the example, you need to install all the dependencies with your favorite package manager:
+To run the example, you need to install all the dependencies with your favorite package manager (including the ones inside the `server` folder):
 
 ```bash
 yarn install

--- a/examples/azure-staticwebapp/package.json
+++ b/examples/azure-staticwebapp/package.json
@@ -23,7 +23,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@azure/static-web-apps-cli": "^1.1.10",
+    "@azure/static-web-apps-cli": "^2.0.1",
     "@remix-run/dev": "^2.10.2",
     "@remix-run/eslint-config": "^2.10.2",
     "@types/react": "^18.3.3",


### PR DESCRIPTION
# Overview
This PR addresses an issue in the example project located at: [Remix Azure Functions Example](https://github.com/scandinavianairlines/remix-azure-functions/tree/main/examples/azure-staticwebapp). The example was outdated due to the library SWA, and upgrading to version 2 resolves the problem.

# Changes
- Upgraded the SWA library version to v2 to fix the development run issue.
- Improved the README documentation for clarity and to reflect the changes.

# Issue Reference
This PR fixes the error related to Axios where the package subpath ./lib/adapters/http was not defined by "exports" from Axios, as reported in the issue https://github.com/scandinavianairlines/remix-azure-functions/issues/163

# Testing
- Tested with Node versions v22.0.0 and bun
- Verified on macOS M1 Sonoma 14.0.

Please review and let me know if any further adjustments are needed.

Thank you!