### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,5 +1,8 @@
 name: Validate
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize]


### PR DESCRIPTION
Potential fix for [https://github.com/scandinavianairlines/remix-azure-functions/security/code-scanning/3](https://github.com/scandinavianairlines/remix-azure-functions/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Based on the workflow's functionality, the minimal required permission is `contents: read`, as the jobs only need to read repository contents to validate commits, lint code, and run tests. No write permissions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
