### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,5 +1,8 @@
 name: Validate
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize]


### PR DESCRIPTION
Potential fix for [https://github.com/scandinavianairlines/remix-azure-functions/security/code-scanning/2](https://github.com/scandinavianairlines/remix-azure-functions/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file to define the minimal permissions required for all jobs. Since the workflow primarily involves reading repository contents (e.g., fetching commits and installing dependencies), the `contents: read` permission is sufficient. This change will ensure that the `GITHUB_TOKEN` has only the necessary permissions, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
